### PR TITLE
Add Setup / build python scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/.vscode
 /workspace
 *.7z

--- a/Tools/build.py
+++ b/Tools/build.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import subprocess
+
+"""
+    Mapbuilder build script, use for dev purposes,
+    Requires arma 3 tools
+"""
+######## GLOBALS #########
+MAINDIR = "mb"
+ADDONDIR = "@MapBuilder"
+PROJECTDIR = "MapBuilder"
+PBOPREFIX = ""
+##########################
+
+def mod_time(path):
+    """Date change comparison"""
+    if not os.path.isdir(path):
+        return os.path.getmtime(path)
+    maxi = os.path.getmtime(path)
+    for p in os.listdir(path):
+        maxi = max(mod_time(os.path.join(path, p)), maxi)
+    return maxi
+
+
+def check_for_changes(foldertopack, module):
+    """Check if folder changed since the PBO was build"""
+    if not os.path.exists(os.path.join(foldertopack, "{}{}.pbo".format(PBOPREFIX,module))):
+        return True
+    return mod_time(os.path.join(foldertopack, module)) > mod_time(os.path.join(foldertopack, "{}{}.pbo".format(PBOPREFIX,module)))
+
+def find_bi_tools():
+    """Find BI tools."""
+
+    import winreg
+    reg = winreg.ConnectRegistry(None, winreg.HKEY_CURRENT_USER)
+    try:
+        k = winreg.OpenKey(reg, r"Software\bohemia interactive\arma 3 tools")
+        arma3tools_path = winreg.QueryValueEx(k, "path")[0]
+        winreg.CloseKey(k)
+    except:
+        raise Exception("BadTools","Arma 3 Tools are not installed correctly.")
+
+    addonbuilder_path = os.path.join(arma3tools_path, "AddonBuilder", "AddonBuilder.exe")
+    dssignfile_path = os.path.join(arma3tools_path, "DSSignFile", "DSSignFile.exe")
+    dscreatekey_path = os.path.join(arma3tools_path, "DSSignFile", "DSCreateKey.exe")
+    cfgconvert_path = os.path.join(arma3tools_path, "CfgConvert", "CfgConvert.exe")
+
+    if os.path.isfile(addonbuilder_path) and os.path.isfile(dssignfile_path) and os.path.isfile(dscreatekey_path) and os.path.isfile(cfgconvert_path):
+        return [addonbuilder_path, dssignfile_path, dscreatekey_path, cfgconvert_path]
+    else:
+        raise Exception("BadTools","Arma 3 Tools are not installed correctly.")
+
+
+def find_a3_install():
+    """Find arma install location (Usually in some steam location)."""
+
+    import winreg
+    try:
+        reg = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
+        key = winreg.OpenKey(reg,
+                r"SOFTWARE\Wow6432Node\bohemia interactive\arma 3")
+        return winreg.EnumValue(key,1)[1]
+    except:
+        print("Failed to determine Arma 3 Path.")
+        return 1
+
+
+def build_da_pbo(addonbuilder, foldertopack):
+    """Builds PBOs using addonBuilder"""
+    global made, failed, skipped, removed
+
+    os.chdir(foldertopack)
+    for p in os.listdir(foldertopack):
+        path = os.path.join(foldertopack, p)
+        if not os.path.isdir(path):
+            continue
+        if p[0] == ".":
+            continue
+        if not check_for_changes(foldertopack, p):
+            skipped += 1
+            print("  Skipping {}.".format(p))
+            continue
+
+        nopackfile = os.path.join(path, "$NOPACK$")
+        if os.path.isfile(nopackfile):
+            print("# No pack {} ...".format(p))
+            continue
+
+        print("# Making {} ...".format(p))
+
+        # Check content of the PBOPREFIX file (why would BIS tools have built-in support for this modding standard?)
+        if os.path.isfile(os.path.join(path, "$PBOPREFIX$.txt")):
+            do_pboprefix = True
+            pboprefix_file = open(os.path.join(path, "$PBOPREFIX$.txt"), 'r')
+            pboprefix_path = (pboprefix_file.readlines()[0])[7:]
+            print(pboprefix_path)
+        else:
+            do_pboprefix = False
+
+        key = None
+        do_binarize = False
+        do_sign = False
+        project_path = "-project="+os.path.abspath("..")
+
+        try:
+            cmd = [addonbuilder, path, os.path.abspath(".\\"), "-clear", project_path]
+            if not do_binarize:
+                cmd.append("-packonly")
+
+            if do_sign:
+                cmd.append("-sign="+key)
+
+            if do_pboprefix:
+                cmd.append("-prefix="+pboprefix_path)
+
+            try:
+                subprocess.check_call(cmd)
+            except:
+                print("Module not successfully built.")
+                raise
+        except:
+            failed += 1
+            print("  Failed to make {}.".format(p))
+        else:
+            made += 1
+            print("  Successfully made {}.".format(p))
+
+def main():
+    """Main build function"""
+    print("""
+  ###################
+  # MapBuilder Build #
+  ###################
+""")
+
+
+    scriptpath = os.path.realpath(__file__)
+    projectpath = os.path.dirname(os.path.dirname(scriptpath))
+    addonspath = os.path.join(projectpath, "addons")
+
+    global made, failed, skipped, removed
+    made = 0
+    failed = 0
+    skipped = 0
+    removed = 0
+
+    try:
+        tools = find_bi_tools()
+        addonbuilder = tools[0]
+        dssignfile = tools[1]
+        dscreatekey = tools[2]
+        cfgconvert = tools[3]
+
+    except:
+        print("Arma 3 Tools are not installed correctly.")
+        sys.exit(1)
+
+    modpath = os.path.join(os.path.dirname(os.path.dirname(scriptpath)), ADDONDIR)
+    addonspath = os.path.join(modpath, "AddOns")
+    build_da_pbo(addonbuilder, addonspath)
+
+    print("\n# Done.")
+    print("  Made {}, skipped {}, removed {}, failed to make {}.".format(made, skipped, removed, failed))
+
+    # repl = input("Press ANY key to exit")
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Tools/setup.py
+++ b/Tools/setup.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+
+"""
+    Mapbuilder setup script, use for dev purposes,
+    symlinks to correct paths so you can use file patching proplery
+"""
+#######################
+#  MapBuilder Setup Script  #
+#######################
+
+import os
+import sys
+import subprocess
+import winreg
+
+######## GLOBALS #########
+MAINDIR = "mb"
+ADDONDIR = "@MapBuilder"
+PROJECTDIR = "MapBuilder"
+##########################
+
+
+def create_link(link_name, target_element):
+    """Creates the symbolic links from, to"""
+    print('Creating link: {} => {}'.format(link_name, target_element))
+    return subprocess.call(["cmd", "/c", "mklink", "/D", "/J", link_name, target_element])
+
+
+def find_a3_install():
+    """Find arma install location (Usually in some steam location)."""
+    try:
+        reg = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
+        key = winreg.OpenKey(reg, r"SOFTWARE\Wow6432Node\bohemia interactive\arma 3")
+        armapath = winreg.EnumValue(key, 1)[1]
+        winreg.CloseKey(key)
+        return armapath
+    except:
+        print("Failed to determine Arma 3 Path.")
+        return 1
+
+def find_bi_tools():
+    """Find BI tools."""
+    try:
+        reg = winreg.ConnectRegistry(None, winreg.HKEY_CURRENT_USER)
+        key = winreg.OpenKey(reg, r"Software\bohemia interactive\arma 3 tools")
+        armatoolspath = winreg.QueryValueEx(key, "path")[0]
+        winreg.CloseKey(key)
+        return armatoolspath
+    except:
+        raise Exception("BadTools", "Arma 3 Tools are not installed correctly.")
+
+def find_workdrive(toolspath):
+    """Finds the actual position of workdrive."""
+    from configparser import ConfigParser
+    from io import StringIO
+
+    config = ConfigParser()
+    with open(os.path.join(toolspath, "settings.ini"), 'r') as inputfile:
+        inputfile = StringIO("[top]\n" + inputfile.read())
+        config.readfp(inputfile)
+        tempath = config['P_Drive']['P_DrivePath']        
+        return tempath.replace('"', '')
+
+def main():
+    """Gets paths, creates symlinks"""
+    fulldir = "{}\\{}".format(MAINDIR, PROJECTDIR)
+    print("""
+  ###########################################
+  # MapBuilder Development Environment Setup #
+  ###########################################
+
+  This script will create your MapBuilder dev environment for you.
+
+  This script will create two hard links on your system, both pointing to your MapBuilder project folder:
+    [Arma 3 installation directory]\\{} => MapBuilder project folder
+    [Arma 3 installation directory]\\{} => MapBuilder addons folder
+    [Work Folder]\\{} => MapBuilder addons folder
+  """.format(fulldir, ADDONDIR, PROJECTDIR))
+    print("\n")
+
+
+    armapath = find_a3_install()
+    toolspath = find_bi_tools()
+    scriptpath = os.path.realpath(__file__)
+    basepath = os.path.dirname(os.path.dirname(scriptpath))
+    modpath = os.path.join(basepath, ADDONDIR)
+    addonspath = os.path.join(modpath, "AddOns")
+    workdrive = find_workdrive(toolspath)
+
+    print("# Detected Paths:")
+    print("  Arma Path:     {}".format(armapath))
+    print("  Project Path:  {}".format(addonspath))
+    print("  Tools Path:  {}".format(toolspath))
+    print("  Work Drive:  {}".format(workdrive))
+
+    repl = input("\nAre these correct? (y/n): ")
+    if repl.lower() != "y":
+        return 3
+
+    print("\n# Creating links ...")
+
+
+    try:
+        create_link(os.path.join(armapath, MAINDIR), addonspath)
+        create_link(os.path.join(armapath, ADDONDIR), modpath)
+        create_link(os.path.join(workdrive, PROJECTDIR), basepath)
+
+    except:
+        raise
+
+    print("# Links created successfully.")
+
+    return 0
+
+if __name__ == "__main__":
+    EXITCODE = main()
+
+    if EXITCODE > 0:
+        print("\nSomething went wrong during the setup. Make sure you run this script as administrator.")
+    else:
+        print("\nSetup successfully completed.")
+
+    input("\nPress enter to exit ...")
+    sys.exit(EXITCODE)


### PR DESCRIPTION
Setup file does symlinks for loading the mod, file patching and workdrive. Build file builds only changed pbos, plus no hardcoded tools path, plus fix BIS' non-existant pboprefix reading